### PR TITLE
json-1 Line numbers in error messages are wrong when file contains comments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>au.gov.aims</groupId>
     <artifactId>json</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
 
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>

--- a/src/main/java/au/gov/aims/json/JSONUtils.java
+++ b/src/main/java/au/gov/aims/json/JSONUtils.java
@@ -68,8 +68,9 @@ public class JSONUtils {
             String line;
             while ((line = bufferedReader.readLine()) != null) {
                 if (!removeComments || !line.trim().startsWith("//")) {
-                    sb.append(line).append("\n");
+                    sb.append(line);
                 }
+                sb.append("\n");
             }
         } finally {
             if (bufferedReader != null) {


### PR DESCRIPTION
Issue #1 ver 1.3.2
- Changed streamToString function to replace comment lines with an empty line